### PR TITLE
Add join failure data handling for network connection logic

### DIFF
--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
@@ -95,7 +95,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x06
+#define HOST_APP_VERSION_MINOR 0x07
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
@@ -678,10 +678,27 @@ void run_state_machine()
             }
 
         case STATE_JOIN_NETWORK: {
-                if (initiate_network_join()) 
-                {
-                    set_state(STATE_READ_SENSOR);
+            // Check for join failure
+            // note: we are not taking join failure actions here, just printing the reason
+            if (mcm.is_join_failure_available()) {
+                uint8_t failure_reason;
+                mcm.get_join_failure_info(&failure_reason);
+                
+                Serial.println("Join failure detected. Checking failure reasons:");
+                
+                if (failure_reason & JOIN_FAIL_REG) {
+                    Serial.println("- Registration failure: Device registration failed");
                 }
+                if (failure_reason & JOIN_FAIL_TIME_SYNC) {
+                    Serial.println("- Time sync failure: Network time synchronization failed");
+                }
+                if (failure_reason & JOIN_FAIL_LINK) {
+                    Serial.println("- Link failure: Network link was lost");
+                }
+            } else if (initiate_network_join()) {
+			 
+                set_state(STATE_READ_SENSOR);
+            }
                 break;
             }
 

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
@@ -107,7 +107,14 @@ typedef struct
     mrover_uplink_event_type_t tx_status;
 } get_tx_status_t;
 
-
+/**
+ * @brief Structure to get the join failure status. 
+ * This is the data for the event 'GET_EVENT_JOIN_FAILURE
+ * 
+ */typedef struct
+{
+    uint8_t failure_reason;
+} get_event_failure_reason_t;
 
 
 /**
@@ -191,6 +198,7 @@ typedef union
     get_evt_class_switch_data_t class_switch_data;
     get_seg_file_status_t download_segment_data;
     get_evt_mac_time_t mac_time;
+    get_event_failure_reason_t failure_reason;
 } get_event_cb_value_t;
 
 
@@ -938,6 +946,14 @@ get_event_code_t mcm_helper_get_event_code(const api_processor_response_t *res);
  * @return The event TX status mrover_uplink_event_type_t
  */
 mrover_uplink_event_type_t mcm_helper_get_event_tx_status(const api_processor_response_t *res);
+
+/**
+ * @brief Get the join failure reason from the API processor response
+ * 
+ * @param[in] res Pointer to the API processor response
+ * @return The join failure reason bitmask. Check JOIN_FAIL_* values in commands_defs.h
+ */
+uint8_t mcm_helper_get_join_failure_reason(const api_processor_response_t *res);
 
 /**
  * @brief Get the device EUI from the API processor response

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/commands_defs.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/commands_defs.h
@@ -290,7 +290,16 @@ typedef enum
     MROVER_LORAWAN_MAC_REQ_ANSWERED = 1,      // MAC request was answered
 }mrover_lorawan_mac_event_t;
 
-
+/**
+ * @brief Join failure reasons that can be combined using bitmasks
+ *															  
+ */
+typedef enum {
+    JOIN_FAIL_NONE        = 0x00,  // No failure
+    JOIN_FAIL_REG         = 0x01,  // Registration went 0→1
+    JOIN_FAIL_TIME_SYNC   = 0x02,  // Time sync went 0→1
+    JOIN_FAIL_LINK        = 0x04   // Link went joined→0
+} join_fail_reason_t;
 /**********************************************************************************************************
  * ExPORTED VARIABLES
  **********************************************************************************************************/

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
@@ -260,15 +260,34 @@ static void handle_mcm_response(const api_processor_response_t *mcm_response, vo
         case MODEM_EVENT_JOINFAIL:
         {
             Serial.printf("MODEM_EVENT_JOINFAIL\n");
+            uint8_t failure_reason = mcm_helper_get_join_failure_reason(mcm_response);
+            
+            // Store the failure reason in the MCM instance for later retrieval
+            curr_instance->set_join_failure_data(failure_reason, true);
+            
             if (COMMAND_TYPE_LORAWAN == mcm_helper_get_command_type(mcm_response))
             {
-                if (curr_instance->get_is_debug_enabled())
-                    Serial.printf("Join fail event occurred\n");
+                if (curr_instance->get_is_debug_enabled()) {
+                    // failure reason not used in case of lorawan should always be 0
+                    Serial.printf("Join fail event occurred with reason: 0x%02X\n", failure_reason);
+                }
             }
             else if (COMMAND_TYPE_SIDEWALK == mcm_helper_get_command_type(mcm_response))
             {
-                if (curr_instance->get_is_debug_enabled())
-                    Serial.printf("Sidewalk time sync fail event\n");
+                if (curr_instance->get_is_debug_enabled()) {
+                    Serial.printf("Sidewalk time sync fail event with reason: 0x%02X\n", failure_reason);
+                    if (failure_reason & JOIN_FAIL_REG) {
+                        Serial.printf("  - Registration failed\n");
+                    }
+                    if (failure_reason & JOIN_FAIL_TIME_SYNC) {
+                        Serial.printf("  - Time sync failed\n");
+                    }
+                    if (failure_reason & JOIN_FAIL_LINK) {
+                        Serial.printf("  - Link failed\n");
+                    }                    if (failure_reason == JOIN_FAIL_NONE) {
+                        Serial.printf("  - No specific reason\n");
+                    }
+                }
             }
             curr_instance->set_is_joined_network(false);
         }
@@ -1441,6 +1460,24 @@ bool MCM::get_context_mgr_is_mcm_reset()
     return return_value;
 }
 
+bool MCM::is_join_failure_available()
+{
+    return this->is_join_failure;
+}
+
+uint8_t MCM::get_join_failure_data()
+{
+    uint8_t failure_reason = this->join_failure_reason;
+    this->is_join_failure = false;  // Reset the flag after retrieving the data
+    return failure_reason;
+}
+
+void MCM::set_join_failure_data(uint8_t failure_reason, bool available)
+{
+    this->join_failure_reason = failure_reason;
+    this->is_join_failure = available;
+}
+
 void MCM::hw_reset()
 {
     Serial.printf("hw_reset\n");
@@ -1767,4 +1804,9 @@ MCM_STATUS MCM::process_fw_update()
         Serial.println("Host firmware present - triggering host firmware update");
         return this->start_file_transfer(seg_file_status.fw_ver);
     }
+}
+
+void MCM::get_join_failure_info(uint8_t *failure_reason)
+{
+    *failure_reason = this->get_join_failure_data();
 }

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -144,6 +144,8 @@ class MCM {
     int8_t rssi;
     uint8_t snr;
     uint16_t seq_port;
+    uint8_t join_failure_reason = 0;
+    bool is_join_failure = false;
     bool is_debug_enabled = false;
     bool _context_mgr_is_joined_cmd_received = false;
     bool _context_mgr_is_mcm_reset;
@@ -208,6 +210,10 @@ public:
     MCM_STATUS req_lorawan_dev_time(void);
     MCM_STATUS get_gps_time(uint32_t *p_gps_time); 
     MCM_STATUS get_last_dl_stats(get_last_dl_stats_t *p_last_dl_stats);
+    bool is_join_failure_available();
+    uint8_t get_join_failure_data();
+    void set_join_failure_data(uint8_t failure_reason, bool available);
+    void get_join_failure_info(uint8_t *failure_reason);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
@@ -2,7 +2,7 @@
   "release_date": "2025-03-21",
   "versions": {
     "mcm": {
-      "application": "0.5.6",
+      "application": "0.5.8",
       "bootloader": "0.1.2",
       "sdk": {
         "simplicity_studio": "SV5.8.0.1",
@@ -16,7 +16,7 @@
       }
     },
     "host": {
-      "application": "0.6.0",
+      "application": "0.7.0",
       "lib_mcm_rover": "0.3.0",
       "lib_api_processor": "0.2.0"
     }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
@@ -87,7 +87,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x05
+#define HOST_APP_VERSION_MINOR 0x06
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
@@ -670,8 +670,25 @@ void run_state_machine()
         }
 
         case STATE_JOIN_NETWORK: {
-            if (initiate_network_join())
-            {
+            // Check for join failure
+            // note: we are not taking join failure actions here, just printing the reason
+            if (mcm.is_join_failure_available()) {
+                uint8_t failure_reason;
+                mcm.get_join_failure_info(&failure_reason);
+                
+                Serial.println("Join failure detected. Checking failure reasons:");
+                
+                if (failure_reason & JOIN_FAIL_REG) {
+                    Serial.println("- Registration failure: Device registration failed");
+                }
+                if (failure_reason & JOIN_FAIL_TIME_SYNC) {
+                    Serial.println("- Time sync failure: Network time synchronization failed");
+                }
+                if (failure_reason & JOIN_FAIL_LINK) {
+                    Serial.println("- Link failure: Network link was lost");
+                }
+            } else if (initiate_network_join()) {
+			 
                 set_state(STATE_READ_SENSOR);
             }
             break;

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
@@ -101,7 +101,14 @@ typedef struct
     mrover_uplink_event_type_t tx_status;
 } get_tx_status_t;
 
-
+/**
+ * @brief Structure to get the join failure status. 
+ * This is the data for the event 'GET_EVENT_JOIN_FAILURE
+ * 
+ */typedef struct
+{
+    uint8_t failure_reason;
+} get_event_failure_reason_t;
 
 
 /**
@@ -178,6 +185,7 @@ typedef union
     get_evt_down_data_t down_data;
     get_evt_class_switch_data_t class_switch_data;
     get_seg_file_status_t download_segment_data;
+    get_event_failure_reason_t failure_reason;
 } get_event_cb_value_t;
 
 
@@ -895,6 +903,14 @@ get_event_code_t mcm_helper_get_event_code(const api_processor_response_t *res);
  * @return The event TX status mrover_uplink_event_type_t
  */
 mrover_uplink_event_type_t mcm_helper_get_event_tx_status(const api_processor_response_t *res);
+
+/**
+ * @brief Get the join failure reason from the API processor response
+ * 
+ * @param[in] res Pointer to the API processor response
+ * @return The join failure reason bitmask. Check JOIN_FAIL_* values in commands_defs.h
+ */
+uint8_t mcm_helper_get_join_failure_reason(const api_processor_response_t *res);
 
 /**
  * @brief Get the device EUI from the API processor response

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/commands_defs.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/commands_defs.h
@@ -276,6 +276,16 @@ typedef enum {
     MROVER_LORAWAN_CLASS_C       = 0x02
 } mrover_lorawan_class_t;
 
+/**
+ * @brief Join failure reasons that can be combined using bitmasks
+ */
+typedef enum {
+    JOIN_FAIL_NONE        = 0x00,  // No failure
+    JOIN_FAIL_REG         = 0x01,  // Registration went 0→1
+    JOIN_FAIL_TIME_SYNC   = 0x02,  // Time sync went 0→1
+    JOIN_FAIL_LINK        = 0x04   // Link went joined→0
+} join_fail_reason_t;
+
 
 /**********************************************************************************************************
  * ExPORTED VARIABLES

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -144,6 +144,8 @@ class MCM {
     int8_t rssi;
     uint8_t snr;
     uint16_t seq_port;
+    uint8_t join_failure_reason = 0;
+    bool is_join_failure = false;
     bool is_debug_enabled = false;
     bool _context_mgr_is_joined_cmd_received = false;
     bool _context_mgr_is_mcm_reset;
@@ -203,6 +205,10 @@ public:
     void set_host_app_version(ver_type_1_t version);
     void retrieveLibraryVersions(ver_type_1_t *mcm_rover_lib_ver, ver_type_1_t *c_lib_ver);
     MCM_STATUS process_fw_update();
+    bool is_join_failure_available();
+    uint8_t get_join_failure_data();
+    void set_join_failure_data(uint8_t failure_reason, bool available);
+    void get_join_failure_info(uint8_t *failure_reason);
 
 };
 

--- a/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
@@ -2,7 +2,7 @@
   "release_date": "2025-03-21",
   "versions": {
     "mcm": {
-      "application": "0.5.6",
+      "application": "0.5.8",
       "bootloader": "0.1.3",
       "sdk": {
         "simplicity_studio": "SV5.8.0.1",
@@ -16,7 +16,7 @@
       }
     },
     "host": {
-      "application": "0.5.0",
+      "application": "0.6.0",
       "lib_mcm_rover": "0.3.0",
       "lib_api_processor": "0.2.0"
     }


### PR DESCRIPTION
This commit implements proper join failure data handling and reporting:

1. Added an enum `join_fail_reason_t` with specific failure reason codes:
   - JOIN_FAIL_NONE (0x00): No failure
   - JOIN_FAIL_REG (0x01): Registration failure
   - JOIN_FAIL_TIME_SYNC (0x02): Time sync failure
   - JOIN_FAIL_LINK (0x04): Link disconnection

2. Implemented event handling for MODEM_EVENT_JOINFAIL in handle_mcm_response():
   - Stores failure reason with set_join_failure_data()
   - Provides detailed debug information for Sidewalk failures
   - Explicitly sets network connection state to false with set_is_joined_network(false)

3. The implementation ensures consistent connection state management:
   - Success case: set_is_joined_network(true) when MODEM_EVENT_JOINED occurs
   - Failure case: set_is_joined_network(false) when MODEM_EVENT_JOINFAIL occurs

No automatic retry logic is implemented at this level