### PR TITLE
feat: Add new CLI command to get the next max mtu length

### DIFF
--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
@@ -95,7 +95,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x07
+#define HOST_APP_VERSION_MINOR 0x08
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************
@@ -180,6 +180,6 @@ int app_queryNextUplink_mtu(uint16_t *mtu);
  * @param[out] mtu Pointer to store the retrieved MTU size
  * @return int 0 on success, non-zero on failure
  */
-int app_getCachedMaxUplink_mtu(uint16_t *mtu);
+int app_getCachedNextUplink_mtu(uint16_t *mtu);
 
 #endif // LRWAN_SIDEWALK_EX_H

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
@@ -165,4 +165,21 @@ int request_lorawan_time_sync(void);
  */
 int app_get_dl_stats(get_last_dl_stats_t *p_last_dl_stats);
 
+/**
+ * @brief query next uplink mtu from modem via a refresh command
+ * 
+ * @param mtu Pointer to store the retrieved MTU size
+ * @return int 0 on success, non-zero on failure
+ */
+
+int app_queryNextUplink_mtu(uint16_t *mtu);
+
+/**
+ * @brief Retrieves the cached next uplink MTU size from the modem. Only queries the modem if the cached value is altered.
+ *
+ * @param[out] mtu Pointer to store the retrieved MTU size
+ * @return int 0 on success, non-zero on failure
+ */
+int app_getCachedMaxUplink_mtu(uint16_t *mtu);
+
 #endif // LRWAN_SIDEWALK_EX_H

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
@@ -259,7 +259,7 @@ static bool send_uplink(float temperature, float humidity)
     }
     
     uint16_t uplink_mtu = 0;
-    if(app_getCachedMaxUplink_mtu(&uplink_mtu) != 0){
+    if(app_getCachedNextUplink_mtu(&uplink_mtu) != 0){
         Serial.println("Failed to get uplink mtu");
         break;
     }
@@ -1106,7 +1106,7 @@ int app_queryNextUplink_mtu(uint16_t *mtu)
     return status != MCM_STATUS::MCM_OK ? -1 : 0;
 }
 
-int app_getCachedMaxUplink_mtu(uint16_t *mtu) {
+int app_getCachedNextUplink_mtu(uint16_t *mtu) {
     
     if(device_mode == ConnectionMode::CONNECTION_MODE_NC){
         return -1; //early return

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
@@ -10,7 +10,7 @@
  * @version 0.1
  * @date 2024-07-08
  * 
- * Copyright (c) 2024 Oxit.
+ * Copyright  (c) 2024 Oxit.
  * All rights reserved.
  * 
  * THE OPEN SOURCE SOFTWARE LICENSE AGREEMENT ("AGREEMENT") IS A BINDING LEGAL CONTRACT BETWEEN YOU ("YOU") AND OXIT, A COMPANY INCORPORATED UNDER THE LAWS OF THE UNITED STATES OF AMERICA ACTING FOR THE PURPOSE OF THIS AGREEMENT THROUGH ITS REGISTERED OFFICE AT OXIT, LLC, 3131 WESTINGHOUSE BLVD, CHARLOTTE, NC 28273.
@@ -257,8 +257,20 @@ static bool send_uplink(float temperature, float humidity)
         Serial.println("Device not connected to network.\n");
             break;
     }
+    
+    uint16_t uplink_mtu = 0;
+    if(app_getCachedMaxUplink_mtu(&uplink_mtu) != 0){
+        Serial.println("Failed to get uplink mtu");
+        break;
+    }
 
-        set_led_state(LED_SENDING_UPLINK);
+    if (uplink_mtu == 0)
+    {
+        Serial.println("Invalid next uplink mtu");
+        break;
+    }
+
+    set_led_state(LED_SENDING_UPLINK);
     // Code to send uplink with temperature and humidity data
     Serial.printf("Sending uplink: Temp = %.2f, Humidity = %.2f, Reboot counter = %d\r\n", temperature, humidity, uplink_data.reboot_count);
 
@@ -1087,3 +1099,46 @@ int app_get_dl_stats(get_last_dl_stats_t *p_last_dl_stats)
 
     return ret;
 }
+
+int app_queryNextUplink_mtu(uint16_t *mtu)
+{
+    MCM_STATUS status = mcm.get_next_uplink_mtu(mtu);
+    return status != MCM_STATUS::MCM_OK ? -1 : 0;
+}
+
+int app_getCachedMaxUplink_mtu(uint16_t *mtu) {
+    
+    if(device_mode == ConnectionMode::CONNECTION_MODE_NC){
+        return -1; //early return
+    }
+
+    int ret = 0;
+    
+    static uint16_t preNextUplink_mtu = 0;
+    static ConnectionMode preActiveProtocol = ConnectionMode::CONNECTION_MODE_NC;
+    if(preActiveProtocol != device_mode || preNextUplink_mtu == 0){
+        preActiveProtocol = device_mode;
+        do{
+            if(mtu == NULL) {
+                Serial.println("Error: Null pointer passed to get_next_uplink_mtu");
+                ret = -1;
+                break;
+            }
+            memset(mtu, 0, sizeof(uint16_t));
+
+            int status = app_queryNextUplink_mtu(mtu);
+            if (status != 0) {
+                Serial.println("Error: Failed to get next uplink MTU");
+                ret = -1;
+                break;
+            }
+
+        }while (0);
+        preNextUplink_mtu = *mtu;
+
+    }else{
+        *mtu = preNextUplink_mtu;
+    }
+    return ret; // or error code
+}
+

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
@@ -273,6 +273,8 @@ typedef union
     get_ver_data_t ver_info;
     get_seg_file_status_t seg_file_status;
     get_last_dl_stats_t last_dl_stats;
+    uint16_t next_uplink_mtu;
+    uint8_t next_uplink_mtu_protocol; // (optional, for protocol byte)
 } cmd_response_data_t;
 
 /**
@@ -904,6 +906,15 @@ api_processor_status_t api_processor_cmd_request_lorawan_dev_time(mcm_module_hdl
  */
 api_processor_status_t api_processor_cmd_get_last_dl_stats(mcm_module_hdl_t *mcm_module);
 
+
+/**
+ * @brief Constructs and sends a command to get the next uplink MTU
+ * 
+ * @param mcm_module Pointer to the MCM module structure
+ * @return api_processor_status_t Returns API_PROCESSOR_SUCCESS on success, or an error code on failure
+ */
+api_processor_status_t api_processor_cmd_get_next_uplink_mtu(mcm_module_hdl_t *mcm_module);
+
 /***********************************Helper Functions Prototypes *********************************/
 
 
@@ -1050,6 +1061,14 @@ void mcm_helper_get_seg_file_status(const api_processor_response_t *res, get_seg
  * @return The LoRaWAN MAC time event
  */
 mrover_lorawan_mac_event_t mcm_helper_get_mac_time_event(const api_processor_response_t *res);
+
+/**
+ * @brief return the next uplink MTU
+ * 
+ * @param res Pointer to the API processor response
+ * @return next uplink MTU
+ */
+uint16_t mcm_helper_get_next_uplink_mtu(const api_processor_response_t *res);
 
 #ifdef __cplusplus
 }

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
@@ -65,7 +65,7 @@ extern "C" {
  *       the patch version number is incremented for bug fixes.
  */
 #define API_PROCESSOR_LIB_MAJOR_VERSION 0
-#define API_PROCESSOR_LIB_MINOR_VERSION 3
+#define API_PROCESSOR_LIB_MINOR_VERSION 4
 #define API_PROCESSOR_LIB_PATCH_VERSION 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/commands_defs.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/commands_defs.h
@@ -201,6 +201,8 @@ typedef enum{
     MROVER_CC_STOP_SID_LORAWAN_NETWORK             = 0x00FE,   // stop lorawan network
     MROVER_CC_INIT_LORAWAN                         = 0x00FF,   // initialize lorawan
     MROVER_CC_SWITCH_NETWORK                       = 0x0100,   // switch network between sidewalk and lorawan
+    MROVER_CC_GET_NEXT_UPLINK_MTU                  = 0x0101,  // get the next maximum allowed uplink payload
+
 }mrover_cc_codes_t;
 
 /**

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/frame_parser.c
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/frame_parser.c
@@ -191,6 +191,7 @@ static bool is_valid_command_code(uint16_t u16_command_code)
     case MROVER_CC_FILE_STATUS:
     case MROVER_CC_TRIGGER_FW_UPDATE:
     case MROVER_CC_GET_LAST_DL_STATS:
+    case MROVER_CC_GET_NEXT_UPLINK_MTU:
         b_is_valid_command_code = true;
         
         break;

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
@@ -715,8 +715,10 @@ static void handle_mcm_response(const api_processor_response_t *mcm_response, vo
      */
     case MROVER_CC_REQUEST_UPLINK:
         Serial.printf("MROVER_CC_REQUEST_UPLINK\n");
+        curr_instance->nextUplink_mtu = mcm_helper_get_next_uplink_mtu(mcm_response);
         if (curr_instance->get_is_debug_enabled())
             Serial.printf("Uplink has been requested successfully\n");
+            Serial.printf("Next uplink MTU: %d\n", curr_instance->nextUplink_mtu);
         break;
 
     /**
@@ -965,7 +967,12 @@ static void handle_mcm_response(const api_processor_response_t *mcm_response, vo
         }
     }
     break;
-
+    case MROVER_CC_GET_NEXT_UPLINK_MTU:
+    {
+        Serial.printf("MROVER_CC_GET_NEXT_UPLINK_MTU\n");
+        curr_instance->nextUplink_mtu = mcm_helper_get_next_uplink_mtu(mcm_response);
+    }
+    break;
     
     default:
         break;
@@ -1809,4 +1816,28 @@ MCM_STATUS MCM::process_fw_update()
 void MCM::get_join_failure_info(uint8_t *failure_reason)
 {
     *failure_reason = this->get_join_failure_data();
+}
+
+MCM_STATUS MCM::get_next_uplink_mtu(uint16_t *mtu)
+{
+    Serial.printf("Starting next uplink MTU retrieval process\n");
+    MCM_STATUS status                 = MCM_STATUS::MCM_ERROR;
+    api_processor_status_t api_status = API_PROCESSOR_ERROR;
+    this->nextUplink_mtu = 0;        // Reset MTU
+    do
+    {
+        _ASSERT_PRINT(mtu != NULL, "Null pointer provided for next uplink MTU");
+
+        api_status = api_processor_cmd_get_next_uplink_mtu(this->module);
+        _ERROR_BREAK(api_status, "Failed to send last downlink stats command");
+
+        this->process_received_data();
+        *mtu             = this->nextUplink_mtu;
+        status           = MCM_STATUS::MCM_OK;
+
+        Serial.printf("Successfully retrieved next uplink MTU: %d\n", *mtu);
+
+    } while (0);
+
+    return status;
 }

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -68,7 +68,7 @@ extern "C" {
 #define BUFFER_SIZE (1036)
 
 #define MCM_ROVER_LIB_VER_MAJOR 0
-#define MCM_ROVER_LIB_VER_MINOR 4
+#define MCM_ROVER_LIB_VER_MINOR 5
 #define MCM_ROVER_LIB_VER_PATCH 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -151,6 +151,7 @@ class MCM {
     bool _context_mgr_is_mcm_reset;
     void process_received_data();
 public:
+    uint16_t nextUplink_mtu;
     uint32_t gps_timestamp;
     bool is_lorawan_mac_time_synced;
     ver_type_1_t host_version;
@@ -214,6 +215,7 @@ public:
     uint8_t get_join_failure_data();
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
+    MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
@@ -189,6 +189,15 @@ hal_error_code_t cli_receive_byte(uint8_t *p_u8_rx_byte);
 
 void helper_print_hex_array(const uint8_t* arr, size_t len);
 
+/**
+ * @brief Get the next uplink mtu callback object
+ * 
+ * @param pu8_input_value The input value (unused for this command).
+ * @param pfun_uart_tx  Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+
 /******************************************************************************/
 /* Global Variable Definition */
 /******************************************************************************/
@@ -286,6 +295,12 @@ cli_command_t cli_commands[] = {{
                                                 CLI_APP_NAME" get_dl_stats <enter>",
                                                 "Retrieve the last downlink statistics",
                                                 get_dl_stats_callback,
+                                            },
+                                            {
+                                                "get_next_uplink_mtu",
+                                                CLI_APP_NAME" get_next_uplink_mtu <enter>",
+                                                "To get next uplink MTU size",
+                                                get_next_uplink_mtu_callback,
                                             },
                                             };
 
@@ -671,5 +686,26 @@ static int get_dl_stats_callback(const char *pu8_input_value, cli_send_bytes_t p
                   "\tTimestamp: %lu\n",
                   dl_stats.protocol_type, dl_stats.rssi, dl_stats.snr, dl_stats.timestamp);
     
+    return 0;
+}
+
+/**
+ * @brief Get the next uplink mtu callback object
+ * 
+ * @param pu8_input_value The input value (unused for this command).
+ * @param pfun_uart_tx  Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx)
+{
+    uint16_t mtu = 0;
+    
+    int status = app_queryNextUplink_mtu(&mtu);
+    if (status != 0) {
+        Serial.println("Error: Failed to get next uplink MTU");
+        return 1;
+    }
+    Serial.print("Next Uplink MTU: ");
+    Serial.println(mtu);
     return 0;
 }

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
@@ -1,5 +1,5 @@
 {
-  "release_date": "2025-03-21",
+  "release_date": "2025-07-03",
   "versions": {
     "mcm": {
       "application": "0.5.8",
@@ -16,9 +16,9 @@
       }
     },
     "host": {
-      "application": "0.7.0",
-      "lib_mcm_rover": "0.3.0",
-      "lib_api_processor": "0.2.0"
+      "application": "0.8.0",
+      "lib_mcm_rover": "0.5.0",
+      "lib_api_processor": "0.4.0"
     }
   }
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
@@ -121,5 +121,21 @@ typedef struct {
  * @param new_mode The new connection mode to switch to.
  */
 void switch_protocol_mode(ConnectionMode new_mode);
+/**
+ * @brief query next uplink mtu from modem via a refresh command
+ * 
+ * @param mtu Pointer to store the retrieved MTU size
+ * @return int 0 on success, non-zero on failure
+ */
+
+int app_queryNextUplink_mtu(uint16_t *mtu);
+
+/**
+ * @brief Retrieves the cached next uplink MTU size from the modem. Only queries the modem if the cached value is altered.
+ *
+ * @param[out] mtu Pointer to store the retrieved MTU size
+ * @return int 0 on success, non-zero on failure
+ */
+int app_getCachedMaxUplink_mtu(uint16_t *mtu);
 
 #endif // ARDUINO_SIDEWALK_EXAMPLE_H

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
@@ -87,7 +87,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x06
+#define HOST_APP_VERSION_MINOR 0x07
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************
@@ -136,6 +136,6 @@ int app_queryNextUplink_mtu(uint16_t *mtu);
  * @param[out] mtu Pointer to store the retrieved MTU size
  * @return int 0 on success, non-zero on failure
  */
-int app_getCachedMaxUplink_mtu(uint16_t *mtu);
+int app_getCachedNextUplink_mtu(uint16_t *mtu);
 
 #endif // ARDUINO_SIDEWALK_EXAMPLE_H

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
@@ -259,7 +259,7 @@ static bool send_uplink(float temperature, float humidity)
         }
 
         uint16_t uplink_mtu = 0;
-        if(app_getCachedMaxUplink_mtu(&uplink_mtu) != 0){
+        if(app_getCachedNextUplink_mtu(&uplink_mtu) != 0){
             Serial.println("Failed to get uplink mtu");
             break;
         }
@@ -948,7 +948,7 @@ int app_queryNextUplink_mtu(uint16_t *mtu)
     return status != MCM_STATUS::MCM_OK ? -1 : 0;
 }
 
-int app_getCachedMaxUplink_mtu(uint16_t *mtu) {
+int app_getCachedNextUplink_mtu(uint16_t *mtu) {
     
     if(device_mode == ConnectionMode::CONNECTION_MODE_NC){
         return -1; //early return

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
@@ -258,6 +258,17 @@ static bool send_uplink(float temperature, float humidity)
             break;
         }
 
+        uint16_t uplink_mtu = 0;
+        if(app_getCachedMaxUplink_mtu(&uplink_mtu) != 0){
+            Serial.println("Failed to get uplink mtu");
+            break;
+        }
+
+        if (uplink_mtu == 0)
+        {
+            Serial.println("Invalid next uplink mtu");
+            break;
+        }
         set_led_state(LED_SENDING_UPLINK);
         // Code to send uplink with temperature and humidity data
         Serial.printf("Sending uplink: Temp = %.2f, Humidity = %.2f, Reboot counter = %d\r\n", temperature, humidity, uplink_data.reboot_count);
@@ -928,4 +939,47 @@ static void check_device_connection()
             is_device_joined = false;                // Reset the joined state if not connected
         }
     }
+}
+
+
+int app_queryNextUplink_mtu(uint16_t *mtu)
+{
+    MCM_STATUS status = mcm.get_next_uplink_mtu(mtu);
+    return status != MCM_STATUS::MCM_OK ? -1 : 0;
+}
+
+int app_getCachedMaxUplink_mtu(uint16_t *mtu) {
+    
+    if(device_mode == ConnectionMode::CONNECTION_MODE_NC){
+        return -1; //early return
+    }
+
+    int ret = 0;
+    
+    static uint16_t preNextUplink_mtu = 0;
+    static ConnectionMode preActiveProtocol = ConnectionMode::CONNECTION_MODE_NC;
+    if(preActiveProtocol != device_mode || preNextUplink_mtu == 0){
+        preActiveProtocol = device_mode;
+        do{
+            if(mtu == NULL) {
+                Serial.println("Error: Null pointer passed to get_next_uplink_mtu");
+                ret = -1;
+                break;
+            }
+            memset(mtu, 0, sizeof(uint16_t));
+
+            int status = app_queryNextUplink_mtu(mtu);
+            if (status != 0) {
+                Serial.println("Error: Failed to get next uplink MTU");
+                ret = -1;
+                break;
+            }
+
+        }while (0);
+        preNextUplink_mtu = *mtu;
+
+    }else{
+        *mtu = preNextUplink_mtu;
+    }
+    return ret; // or error code
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.c
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.c
@@ -86,6 +86,7 @@ static api_processor_status_t api_processor_parse_get_event_seg(mcm_module_hdl_t
 static api_processor_status_t api_processor_parse_get_file_status(mcm_module_hdl_t *mcm_module,uint8_t *data, uint16_t len, api_processor_response_t *p_response);
 static api_processor_status_t api_processor_handle_request_uplink(mcm_module_hdl_t *mcm_module, uint8_t *data, uint16_t len, api_processor_response_t *p_response);
 static api_processor_status_t api_processor_get_event_join_failure(mcm_module_hdl_t *mcm_module,uint8_t *data, uint16_t len, api_processor_response_t *p_response);
+static api_processor_status_t api_processor_parse_get_next_uplink_mtu(mcm_module_hdl_t *mcm_module, uint8_t *data, uint16_t len, api_processor_response_t *p_response);
 
 /******************************************************************************
  * STATIC FUNCTIONS
@@ -200,7 +201,10 @@ static api_processor_status_t api_processor_parse_response_frame(mcm_module_hdl_
         break;
         case MROVER_CC_FILE_STATUS:
         return_status = api_processor_parse_get_file_status(mcm_module, &data[6], payload_len, p_response);
-        break;
+        break;        
+        case MROVER_CC_GET_NEXT_UPLINK_MTU:     
+            return_status = api_processor_parse_get_next_uplink_mtu(mcm_module, &data[6], payload_len, p_response);
+            break;
 
         default:
             TRACE_INFO("Wrong type of the command code received\n");
@@ -965,6 +969,10 @@ void mcm_helper_get_seg_file_status(const api_processor_response_t *res, get_seg
 inline uint8_t mcm_helper_get_join_failure_reason(const api_processor_response_t *res)
 {
     return res->cmd_response_data.get_event_data.get_event_data_value.failure_reason.failure_reason;
+}
+
+inline uint16_t mcm_helper_get_next_uplink_mtu(const api_processor_response_t *res) {
+    return res->cmd_response_data.next_uplink_mtu;
 }
 /******************************************************************************
  * Function Definitions
@@ -2475,17 +2483,15 @@ static api_processor_status_t api_processor_handle_request_uplink(mcm_module_hdl
     api_processor_status_t return_status = API_PROCESSOR_ERROR;
 
     // Basic sanity checks
-    if (data == NULL || len < 1) {
+    if (data == NULL || len < 2) {
         TRACE_INFO("Invalid data for uplink request\n");
         return API_PROCESSOR_INVALID_PARAMETERS;
     }
 
-    // Debug print to indicate the start of processing the uplink request
-    TRACE_INFO("Processing uplink request with length: %d\n", len);
+    // Parse MTU for next uplink (2 bytes, big-endian)
+    p_response->cmd_response_data.next_uplink_mtu = (data[0] << 8) | data[1];
 
-    // @todo : Noman - Process the uplink request here
 
-    // Assuming processing is successful
     return_status = API_PROCESSOR_SUCCESS;
 
     return return_status;
@@ -2530,6 +2536,53 @@ static api_processor_status_t api_processor_get_event_join_failure(mcm_module_hd
     return return_status;
 }
 
+
+static api_processor_status_t api_processor_parse_get_next_uplink_mtu(mcm_module_hdl_t *mcm_module, uint8_t *data, uint16_t len, api_processor_response_t *p_response)
+{
+    api_processor_status_t return_status = API_PROCESSOR_ERROR;
+    do {
+        if (len < 3) { // 1 byte protocol + 2 bytes MTU
+            TRACE_INFO("Invalid payload length for GET_NEXT_UPLINK_MTU\n");
+            break;
+        }
+        p_response->cmd_response_data.next_uplink_mtu_protocol = data[0];
+        p_response->cmd_response_data.next_uplink_mtu = (data[1] << 8) | data[2];
+        return_status = API_PROCESSOR_SUCCESS;
+    } while (0);
+    return return_status;
+}
+
+api_processor_status_t api_processor_cmd_get_next_uplink_mtu(mcm_module_hdl_t *mcm_module)
+{
+    api_processor_status_t return_status = API_PROCESSOR_ERROR;
+    const uint16_t max_payload_size = 6;
+    do {
+        if (NULL == mcm_module || NULL == mcm_module->h_serial_device.send_data_cb) {
+            TRACE_INFO("MCM module is not initialized\n");
+            break;
+        }
+        memset(mcm_module->u8_send_payload, 0, MAX_SERIAL_SEND_PAYLOAD_SIZE);
+        mcm_module->u8_send_payload[0] = COMMAND_TYPE_GENERAL;
+        mcm_module->u8_send_payload[1] = MROVER_CC_GET_NEXT_UPLINK_MTU >> 8;
+        mcm_module->u8_send_payload[2] = MROVER_CC_GET_NEXT_UPLINK_MTU & 0xFF;
+        mcm_module->u8_send_payload[3] = 0x00;
+        mcm_module->u8_send_payload[4] = 0x00;
+        mcm_module->u8_send_payload[5] = 0x00;
+        fp_api_status_t status = fp_append_crc(mcm_module->u8_send_payload, max_payload_size);
+        if (FP_SUCCESS != status) {
+            TRACE_INFO("Failed to append crc\n");
+            break;
+        }
+        uint16_t u16_sent_bytes = mcm_module->h_serial_device.send_data_cb(mcm_module->u8_send_payload, max_payload_size, mcm_module->user_context);
+        if (max_payload_size != u16_sent_bytes) {
+            TRACE_INFO("Failed to send data through serial port\n");
+            return_status = API_PROCESSOR_SERIAL_PORT_ERROR;
+            break;
+        }
+        return_status = API_PROCESSOR_SUCCESS;
+    } while (0);
+    return return_status;
+}
 
 
 

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
@@ -65,7 +65,7 @@ extern "C" {
  *       the patch version number is incremented for bug fixes.
  */
 #define API_PROCESSOR_LIB_MAJOR_VERSION 0
-#define API_PROCESSOR_LIB_MINOR_VERSION 2
+#define API_PROCESSOR_LIB_MINOR_VERSION 3
 #define API_PROCESSOR_LIB_PATCH_VERSION 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
@@ -256,6 +256,8 @@ typedef union
     const uint8_t* dev_eui;
     const uint8_t* join_eui;
     get_seg_file_status_t seg_file_status;
+    uint16_t next_uplink_mtu;
+    uint8_t next_uplink_mtu_protocol; // (optional, for protocol byte)
 } cmd_response_data_t;
 
 /**
@@ -859,7 +861,13 @@ api_processor_status_t api_processor_cmd_get_seg_file_transfer_status(mcm_module
  */
 api_processor_status_t api_processor_cmd_trigger_fw_update(mcm_module_hdl_t *mcm_module, ver_type_1_t version);
 
-
+/**
+ * @brief Constructs and sends a command to get the next uplink MTU
+ * 
+ * @param mcm_module Pointer to the MCM module structure
+ * @return api_processor_status_t Returns API_PROCESSOR_SUCCESS on success, or an error code on failure
+ */
+api_processor_status_t api_processor_cmd_get_next_uplink_mtu(mcm_module_hdl_t *mcm_module);
 
 /***********************************Helper Functions Prototypes *********************************/
 
@@ -976,6 +984,15 @@ get_seg_file_status_t mcm_helper_get_event_seg_down(const api_processor_response
 mrover_lorawan_class_t mcm_helper_get_device_class(const api_processor_response_t *res);
 
 void mcm_helper_get_seg_file_status(const api_processor_response_t *res, get_seg_file_status_t *seg_file_status);
+
+/**
+ * @brief return the next uplink MTU
+ * 
+ * @param res Pointer to the API processor response
+ * @return next uplink MTU
+ */
+uint16_t mcm_helper_get_next_uplink_mtu(const api_processor_response_t *res);
+
 
 #ifdef __cplusplus
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/commands_defs.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/commands_defs.h
@@ -198,6 +198,8 @@ typedef enum{
     MROVER_CC_START_FILE_TRANSFER                  = 0x00D3,   // start file transfer
     MROVER_CC_FILE_STATUS                          = 0x00D4,   // get file status
     MROVER_CC_TRIGGER_FW_UPDATE                    = 0x00D5,   // trigger firmware update
+    MROVER_CC_GET_NEXT_UPLINK_MTU                  = 0x0101,  // get the next maximum allowed uplink payload
+
 }mrover_cc_codes_t;
 
 /**

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/frame_parser.c
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/frame_parser.c
@@ -187,6 +187,7 @@ static bool is_valid_command_code(uint16_t u16_command_code)
     case MROVER_CC_START_FILE_TRANSFER:
     case MROVER_CC_FILE_STATUS:
     case MROVER_CC_TRIGGER_FW_UPDATE:
+    case MROVER_CC_GET_NEXT_UPLINK_MTU:
         b_is_valid_command_code = true;
         
         break;

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -68,7 +68,7 @@ extern "C" {
 #define BUFFER_SIZE (1036)
 
 #define MCM_ROVER_LIB_VER_MAJOR 0
-#define MCM_ROVER_LIB_VER_MINOR 3
+#define MCM_ROVER_LIB_VER_MINOR 4
 #define MCM_ROVER_LIB_VER_PATCH 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -152,6 +152,7 @@ class MCM {
     void process_received_data();
     
 public:
+    uint16_t nextUplink_mtu;
     ver_type_1_t host_version;
     YModem ymodem;
     bool is_new_firmware_downloaded = false;
@@ -209,7 +210,7 @@ public:
     uint8_t get_join_failure_data();
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
-
+    MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
@@ -161,6 +161,15 @@ hal_error_code_t cli_receive_byte(uint8_t *p_u8_rx_byte);
 
 void helper_print_hex_array(const uint8_t* arr, size_t len);
 
+/**
+ * @brief Get the next uplink mtu callback object
+ * 
+ * @param pu8_input_value The input value (unused for this command).
+ * @param pfun_uart_tx  Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+
 /******************************************************************************/
 /* Global Variable Definition */
 /******************************************************************************/
@@ -241,7 +250,12 @@ cli_command_t cli_commands[] = {{
                                                 "Switch protocol mode. Modes: lorawan, sw_ble, sw_fsk, sw_css",
                                                 protocol_switch_callback,
                                             },
-
+                                            {
+                                                "get_next_uplink_mtu",
+                                                CLI_APP_NAME" get_next_uplink_mtu <enter>",
+                                                "To get next uplink MTU size",
+                                                get_next_uplink_mtu_callback,
+                                            },
                                             };
 
 cli_app_t register_app = {  CLI_APP_NAME, 
@@ -557,4 +571,24 @@ static int protocol_switch_callback(const char *pu8_input_value, cli_send_bytes_
     // Call the new protocol switch API to update the mode
     switch_protocol_mode(new_mode);
     return 1;
+}
+/**
+ * @brief Get the next uplink mtu callback object
+ * 
+ * @param pu8_input_value The input value (unused for this command).
+ * @param pfun_uart_tx  Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx)
+{
+    uint16_t mtu = 0;
+    
+    int status = app_queryNextUplink_mtu(&mtu);
+    if (status != 0) {
+        Serial.println("Error: Failed to get next uplink MTU");
+        return 1;
+    }
+    Serial.print("Next Uplink MTU: ");
+    Serial.println(mtu);
+    return 0;
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
@@ -1,5 +1,5 @@
 {
-  "release_date": "2025-03-21",
+  "release_date": "2025-07-03",
   "versions": {
     "mcm": {
       "application": "0.5.8",
@@ -16,9 +16,9 @@
       }
     },
     "host": {
-      "application": "0.6.0",
-      "lib_mcm_rover": "0.3.0",
-      "lib_api_processor": "0.2.0"
+      "application": "0.7.0",
+      "lib_mcm_rover": "0.4.0",
+      "lib_api_processor": "0.3.0"
     }
   }
 }


### PR DESCRIPTION
### Description
This PR introduces a new CLI command to retrieve the MTU (Maximum Transmission Unit) from the MCM. The changes include:

- Adding a new get_next_uplink_mtu CLI command to fetch the MTU length

- Exposing the command functionality to the application layer

-  Updating the uplink request flow to include a sanity check prior to execution

### How to test
You can test the feature in two ways:

- [ ]  Direct CLI Test

Run the following command:

`oxit_cli get_next_uplink_mtu`

You should see the next uplink MTU value printed.

- [ ]  Indirect Test via Uplink Request

Trigger an uplink request. After successful execution, the MTU will be retrieved and printed as part of the response.