### PR TITLE
Sidawalk css power profile switching

### DIFF
--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
@@ -182,4 +182,12 @@ int app_queryNextUplink_mtu(uint16_t *mtu);
  */
 int app_getCachedNextUplink_mtu(uint16_t *mtu);
 
+/**
+ * @brief Set the CSS power profile for the Sidewalk CSS connection
+ * 
+ * @param profile Profile to be set A or B
+ * @return int 0 on success, non-zero on failure 
+ */
+int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) ;
+
 #endif // LRWAN_SIDEWALK_EX_H

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.h
@@ -95,7 +95,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x08
+#define HOST_APP_VERSION_MINOR 0x09
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
@@ -1150,7 +1150,7 @@ int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
 
   if (is_device_joined == false ||
       device_mode != ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS) {
-    Serial.println("Current running mode is not sidewalk CCS");
+    Serial.println("Current running mode is not sidewalk CSS");
     return -1; // early return
   }
 
@@ -1162,7 +1162,7 @@ int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
   }
 
   // Set the power profile for the Sidewalk CSS connection
-  mcm.sw_setCssPwrProfile((uint8_t)profile);
+  mcm.app_SWSetCSSPwrProfile(profile);
   SW_currentPwrProfile = profile;
   // Print the selected power profile
   char prof_ch[MROVER_CSS_PWR_PROFILE_B + 1] = {'A', 'B'};

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/ArduinoMultiprotocolExample.ino
@@ -962,6 +962,7 @@ static void check_device_connection()
                     break;
                 case ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS:
                     set_led_state(LED_JOINED_SW_CSS_NETWORK);
+                    app_SwSetCssPwrProfile(MROVER_CSS_PWR_PROFILE_A);
                     break;
                 default:
                     Serial.println("No Connection (NC)");
@@ -1142,3 +1143,30 @@ int app_getCachedNextUplink_mtu(uint16_t *mtu) {
     return ret; // or error code
 }
 
+int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
+  if (profile > MROVER_CSS_PWR_PROFILE_B) {
+    return -1;
+  }
+
+  if (is_device_joined == false ||
+      device_mode != ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS) {
+    Serial.println("Current running mode is not sidewalk CCS");
+    return -1; // early return
+  }
+
+  static mrover_css_pwr_profile_t SW_currentPwrProfile =
+      (mrover_css_pwr_profile_t)0xFF;
+  if (SW_currentPwrProfile == profile) {
+    Serial.printf("Sidewalk CSS Power Profile already set to: %d\n", profile);
+    return 0; // No change needed
+  }
+
+  // Set the power profile for the Sidewalk CSS connection
+  mcm.sw_setCssPwrProfile((uint8_t)profile);
+  SW_currentPwrProfile = profile;
+  // Print the selected power profile
+  char prof_ch[MROVER_CSS_PWR_PROFILE_B + 1] = {'A', 'B'};
+  Serial.printf("Sidewalk CSS Power Profile set to: %c\n", prof_ch[profile]);
+
+  return 0;
+}

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/api_processor.h
@@ -65,7 +65,7 @@ extern "C" {
  *       the patch version number is incremented for bug fixes.
  */
 #define API_PROCESSOR_LIB_MAJOR_VERSION 0
-#define API_PROCESSOR_LIB_MINOR_VERSION 4
+#define API_PROCESSOR_LIB_MINOR_VERSION 5
 #define API_PROCESSOR_LIB_PATCH_VERSION 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
@@ -1842,21 +1842,20 @@ MCM_STATUS MCM::get_next_uplink_mtu(uint16_t *mtu)
     return status;
 }
 
-MCM_STATUS MCM::sw_setCssPwrProfile(uint8_t prof) {
-  Serial.printf("Setting sidwalk ccs power profile\n");
+MCM_STATUS MCM::app_SWSetCSSPwrProfile(mrover_css_pwr_profile_t prof) {
+  Serial.printf("Setting sidwalk css power profile\n");
   MCM_STATUS status = MCM_STATUS::MCM_ERROR;
   api_processor_status_t api_status = API_PROCESSOR_ERROR;
   do {
-    api_status = api_processor_cmd_sid_set_css_profile(
-        this->module, (mrover_css_pwr_profile_t)prof);
+    api_status = api_processor_cmd_sid_set_css_profile(this->module, prof);
     _ERROR_BREAK(api_status,
-                 "Failed to send sidewalk set ccs power profile command");
+                 "Failed to send sidewalk set css power profile command");
 
     this->process_received_data();
 
     status = MCM_STATUS::MCM_OK;
     Serial.printf(
-        "Successfully requested change of sidewalk ccs power profile\n");
+        "Successfully requested change of sidewalk css power profile\n");
   } while (0);
 
   return status;

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.cpp
@@ -1841,3 +1841,23 @@ MCM_STATUS MCM::get_next_uplink_mtu(uint16_t *mtu)
 
     return status;
 }
+
+MCM_STATUS MCM::sw_setCssPwrProfile(uint8_t prof) {
+  Serial.printf("Setting sidwalk ccs power profile\n");
+  MCM_STATUS status = MCM_STATUS::MCM_ERROR;
+  api_processor_status_t api_status = API_PROCESSOR_ERROR;
+  do {
+    api_status = api_processor_cmd_sid_set_css_profile(
+        this->module, (mrover_css_pwr_profile_t)prof);
+    _ERROR_BREAK(api_status,
+                 "Failed to send sidewalk set ccs power profile command");
+
+    this->process_received_data();
+
+    status = MCM_STATUS::MCM_OK;
+    Serial.printf(
+        "Successfully requested change of sidewalk ccs power profile\n");
+  } while (0);
+
+  return status;
+}

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -68,7 +68,7 @@ extern "C" {
 #define BUFFER_SIZE (1036)
 
 #define MCM_ROVER_LIB_VER_MAJOR 0
-#define MCM_ROVER_LIB_VER_MINOR 5
+#define MCM_ROVER_LIB_VER_MINOR 6
 #define MCM_ROVER_LIB_VER_PATCH 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -216,6 +216,7 @@ public:
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
     MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
+    MCM_STATUS sw_setCssPwrProfile(uint8_t prof);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/mcm_rover.h
@@ -216,7 +216,7 @@ public:
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
     MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
-    MCM_STATUS sw_setCssPwrProfile(uint8_t prof);
+    MCM_STATUS app_SWSetCSSPwrProfile(mrover_css_pwr_profile_t prof);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
@@ -198,6 +198,15 @@ void helper_print_hex_array(const uint8_t* arr, size_t len);
  */
 static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
 
+/**
+ * @brief Set the CSS power profile callback
+ * 
+ * @param pu8_input_value input value (profile value)
+ * @param pfun_uart_tx Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int sw_setCssPwrProfile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+
 /******************************************************************************/
 /* Global Variable Definition */
 /******************************************************************************/
@@ -301,6 +310,12 @@ cli_command_t cli_commands[] = {{
                                                 CLI_APP_NAME" get_next_uplink_mtu <enter>",
                                                 "To get next uplink MTU size",
                                                 get_next_uplink_mtu_callback,
+                                            },
+                                            {
+                                                "sidewalk_ccs_prof_switch",
+                                                CLI_APP_NAME" sidewalk_ccs_prof_switch <profile>",
+                                                "To set the sidewalk ccs profile",
+                                                sw_setCssPwrProfile_callback,
                                             },
                                             };
 
@@ -708,4 +723,38 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
     Serial.print("Next Uplink MTU: ");
     Serial.println(mtu);
     return 0;
+}
+
+static int sw_setCssPwrProfile_callback(const char *pu8_input_value,
+                                        cli_send_bytes_t pfun_uart_tx) {
+  // Check if user supplied a mode string
+  uint8_t len = strlen(pu8_input_value);
+  if (pu8_input_value == NULL || len == 0 || len > 8) {
+    Serial.println("Usage: sidewalk_ccs_prof_switch <profile>");
+    Serial.println("Available modes: prof_a and prof_b");
+    return 1;
+  }
+
+  // Copy and convert the parameter to lower-case for simple comparison
+  char mode_param[8] = {0};
+  strncpy(mode_param, pu8_input_value, len);
+  for (int i = 0; i < len; i++) {
+    mode_param[i] = tolower(mode_param[i]);
+  }
+
+  // Parse the parameter and prepare the corresponding ConnectionMode value
+  mrover_css_pwr_profile_t prof = (mrover_css_pwr_profile_t)0xFF;
+  if (strcmp(mode_param, "prof_a") == 0) {
+    prof = MROVER_CSS_PWR_PROFILE_A;
+  } else if (strcmp(mode_param, "prof_b") == 0) {
+    prof = MROVER_CSS_PWR_PROFILE_B;
+  } else {
+    Serial.println("Invalid protocol profile specified.");
+    Serial.println("Available modes: prof_a, prof_b");
+    return 1;
+  }
+  // Call the new protocol switch API to update the mode
+  app_SwSetCssPwrProfile(prof);
+
+  return 0;
 }

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/ArduinoMultiprotocolExample/oxit_cli_app.cpp
@@ -205,7 +205,7 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
  * @param pfun_uart_tx Function to send bytes over UART.
  * @return int Return status code.
  */
-static int sw_setCssPwrProfile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+static int sw_set_css_pwr_profile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
 
 /******************************************************************************/
 /* Global Variable Definition */
@@ -312,10 +312,10 @@ cli_command_t cli_commands[] = {{
                                                 get_next_uplink_mtu_callback,
                                             },
                                             {
-                                                "sidewalk_ccs_prof_switch",
-                                                CLI_APP_NAME" sidewalk_ccs_prof_switch <profile>",
-                                                "To set the sidewalk ccs profile",
-                                                sw_setCssPwrProfile_callback,
+                                                "sidewalk_css_prof_switch",
+                                                CLI_APP_NAME" sidewalk_css_prof_switch <profile>",
+                                                "To set the sidewalk css profile",
+                                                sw_set_css_pwr_profile_callback,
                                             },
                                             };
 
@@ -725,18 +725,18 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
     return 0;
 }
 
-static int sw_setCssPwrProfile_callback(const char *pu8_input_value,
+static int sw_set_css_pwr_profile_callback(const char *pu8_input_value,
                                         cli_send_bytes_t pfun_uart_tx) {
   // Check if user supplied a mode string
   uint8_t len = strlen(pu8_input_value);
-  if (pu8_input_value == NULL || len == 0 || len > 8) {
-    Serial.println("Usage: sidewalk_ccs_prof_switch <profile>");
+  if (pu8_input_value == NULL || len == 0 || len > 7) {
+    Serial.println("Usage: sidewalk_css_prof_switch <profile>");
     Serial.println("Available modes: prof_a and prof_b");
     return 1;
   }
 
   // Copy and convert the parameter to lower-case for simple comparison
-  char mode_param[8] = {0};
+  char mode_param[7] = {0};
   strncpy(mode_param, pu8_input_value, len);
   for (int i = 0; i < len; i++) {
     mode_param[i] = tolower(mode_param[i]);

--- a/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherMultiProtocol/mcm_release_versions.json
@@ -1,5 +1,5 @@
 {
-  "release_date": "2025-07-03",
+  "release_date": "2025-07-10",
   "versions": {
     "mcm": {
       "application": "0.5.8",
@@ -16,9 +16,9 @@
       }
     },
     "host": {
-      "application": "0.8.0",
-      "lib_mcm_rover": "0.5.0",
-      "lib_api_processor": "0.4.0"
+      "application": "0.9.0",
+      "lib_mcm_rover": "0.6.0",
+      "lib_api_processor": "0.5.0"
     }
   }
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
@@ -138,4 +138,12 @@ int app_queryNextUplink_mtu(uint16_t *mtu);
  */
 int app_getCachedNextUplink_mtu(uint16_t *mtu);
 
+/**
+ * @brief Set the CSS power profile for the Sidewalk CSS connection
+ * 
+ * @param profile Profile to be set A or B
+ * @return int 0 on success, non-zero on failure 
+ */
+int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) ;
+
 #endif // ARDUINO_SIDEWALK_EXAMPLE_H

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.h
@@ -87,7 +87,7 @@
 // Manufacturing mode and version information
 #define ENABLE_MANUFACTURING_MODE 0
 #define HOST_APP_VERSION_MAJOR 0x00
-#define HOST_APP_VERSION_MINOR 0x07
+#define HOST_APP_VERSION_MINOR 0x08
 #define HOST_APP_VERSION_PATCH 0x00
 
 /******************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
@@ -992,7 +992,7 @@ int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
 
   if (is_device_joined == false ||
       device_mode != ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS) {
-    Serial.println("Current running mode is not sidewalk CCS");
+    Serial.println("Current running mode is not sidewalk CSS");
     return -1; // early return
   }
 
@@ -1004,7 +1004,7 @@ int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
   }
 
   // Set the power profile for the Sidewalk CSS connection
-  mcm.sw_setCssPwrProfile((uint8_t)profile);
+  mcm.app_SWSetCSSPwrProfile(profile);
   SW_currentPwrProfile = profile;
   // Print the selected power profile
   char prof_ch[MROVER_CSS_PWR_PROFILE_B + 1] = {'A', 'B'};

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/ArduinoSidewalkExample.ino
@@ -923,6 +923,7 @@ static void check_device_connection()
                     break;
                 case ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS:
                     set_led_state(LED_JOINED_SW_CSS_NETWORK);
+                    app_SwSetCssPwrProfile(MROVER_CSS_PWR_PROFILE_A);
                     break;
                 default:
                     Serial.println("No Connection (NC)");
@@ -982,4 +983,32 @@ int app_getCachedNextUplink_mtu(uint16_t *mtu) {
         *mtu = preNextUplink_mtu;
     }
     return ret; // or error code
+}
+
+int app_SwSetCssPwrProfile(mrover_css_pwr_profile_t profile) {
+  if (profile > MROVER_CSS_PWR_PROFILE_B) {
+    return -1;
+  }
+
+  if (is_device_joined == false ||
+      device_mode != ConnectionMode::CONNECTION_MODE_SIDEWALK_CSS) {
+    Serial.println("Current running mode is not sidewalk CCS");
+    return -1; // early return
+  }
+
+  static mrover_css_pwr_profile_t SW_currentPwrProfile =
+      (mrover_css_pwr_profile_t)0xFF;
+  if (SW_currentPwrProfile == profile) {
+    Serial.printf("Sidewalk CSS Power Profile already set to: %d\n", profile);
+    return 0; // No change needed
+  }
+
+  // Set the power profile for the Sidewalk CSS connection
+  mcm.sw_setCssPwrProfile((uint8_t)profile);
+  SW_currentPwrProfile = profile;
+  // Print the selected power profile
+  char prof_ch[MROVER_CSS_PWR_PROFILE_B + 1] = {'A', 'B'};
+  Serial.printf("Sidewalk CSS Power Profile set to: %c\n", prof_ch[profile]);
+
+  return 0;
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/api_processor.h
@@ -65,7 +65,7 @@ extern "C" {
  *       the patch version number is incremented for bug fixes.
  */
 #define API_PROCESSOR_LIB_MAJOR_VERSION 0
-#define API_PROCESSOR_LIB_MINOR_VERSION 3
+#define API_PROCESSOR_LIB_MINOR_VERSION 4
 #define API_PROCESSOR_LIB_PATCH_VERSION 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.cpp
@@ -1621,3 +1621,25 @@ MCM_STATUS MCM::get_next_uplink_mtu(uint16_t *mtu)
 
     return status;
 }
+
+MCM_STATUS MCM::sw_setCssPwrProfile(uint8_t prof) {
+  Serial.printf("Setting sidwalk ccs power profile\n");
+  MCM_STATUS status = MCM_STATUS::MCM_ERROR;
+  api_processor_status_t api_status = API_PROCESSOR_ERROR;
+  do {
+    api_status = api_processor_cmd_sid_set_css_profile(
+        this->module, (mrover_css_pwr_profile_t)prof);
+
+    if (api_status != 0) {
+      break;
+    }
+
+    this->process_received_data();
+
+    status = MCM_STATUS::MCM_OK;
+    Serial.printf(
+        "Successfully requested change of sidewalk ccs power profile\n");
+  } while (0);
+
+  return status;
+}

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.cpp
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.cpp
@@ -1622,13 +1622,12 @@ MCM_STATUS MCM::get_next_uplink_mtu(uint16_t *mtu)
     return status;
 }
 
-MCM_STATUS MCM::sw_setCssPwrProfile(uint8_t prof) {
-  Serial.printf("Setting sidwalk ccs power profile\n");
+MCM_STATUS MCM::app_SWSetCSSPwrProfile(mrover_css_pwr_profile_t prof) {
+  Serial.printf("Setting sidwalk css power profile\n");
   MCM_STATUS status = MCM_STATUS::MCM_ERROR;
   api_processor_status_t api_status = API_PROCESSOR_ERROR;
   do {
-    api_status = api_processor_cmd_sid_set_css_profile(
-        this->module, (mrover_css_pwr_profile_t)prof);
+    api_status = api_processor_cmd_sid_set_css_profile(this->module, prof);
 
     if (api_status != 0) {
       break;
@@ -1638,7 +1637,7 @@ MCM_STATUS MCM::sw_setCssPwrProfile(uint8_t prof) {
 
     status = MCM_STATUS::MCM_OK;
     Serial.printf(
-        "Successfully requested change of sidewalk ccs power profile\n");
+        "Successfully requested change of sidewalk css power profile\n");
   } while (0);
 
   return status;

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -211,6 +211,7 @@ public:
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
     MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
+    MCM_STATUS sw_setCssPwrProfile(uint8_t prof);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -68,7 +68,7 @@ extern "C" {
 #define BUFFER_SIZE (1036)
 
 #define MCM_ROVER_LIB_VER_MAJOR 0
-#define MCM_ROVER_LIB_VER_MINOR 4
+#define MCM_ROVER_LIB_VER_MINOR 5
 #define MCM_ROVER_LIB_VER_PATCH 0
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/mcm_rover.h
@@ -211,7 +211,7 @@ public:
     void set_join_failure_data(uint8_t failure_reason, bool available);
     void get_join_failure_info(uint8_t *failure_reason);
     MCM_STATUS get_next_uplink_mtu(uint16_t *mtu);
-    MCM_STATUS sw_setCssPwrProfile(uint8_t prof);
+    MCM_STATUS app_SWSetCSSPwrProfile(mrover_css_pwr_profile_t prof);
 };
 
 /**********************************************************************************************************

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
@@ -168,7 +168,16 @@ void helper_print_hex_array(const uint8_t* arr, size_t len);
  * @param pfun_uart_tx  Function to send bytes over UART.
  * @return int Return status code.
  */
+
 static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+/**
+ * @brief Set the CSS power profile callback
+ * 
+ * @param pu8_input_value input value (profile value)
+ * @param pfun_uart_tx Function to send bytes over UART.
+ * @return int Return status code.
+ */
+static int sw_setCssPwrProfile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
 
 /******************************************************************************/
 /* Global Variable Definition */
@@ -255,6 +264,12 @@ cli_command_t cli_commands[] = {{
                                                 CLI_APP_NAME" get_next_uplink_mtu <enter>",
                                                 "To get next uplink MTU size",
                                                 get_next_uplink_mtu_callback,
+                                            },
+                                            {
+                                                "sidewalk_ccs_prof_switch",
+                                                CLI_APP_NAME" sidewalk_ccs_prof_switch <profile>",
+                                                "To set the sidewalk ccs profile",
+                                                sw_setCssPwrProfile_callback,
                                             },
                                             };
 
@@ -591,4 +606,38 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
     Serial.print("Next Uplink MTU: ");
     Serial.println(mtu);
     return 0;
+}
+
+static int sw_setCssPwrProfile_callback(const char *pu8_input_value,
+                                        cli_send_bytes_t pfun_uart_tx) {
+  // Check if user supplied a mode string
+  uint8_t len = strlen(pu8_input_value);
+  if (pu8_input_value == NULL || len == 0 || len > 8) {
+    Serial.println("Usage: sidewalk_ccs_prof_switch <profile>");
+    Serial.println("Available modes: prof_a and prof_b");
+    return 1;
+  }
+
+  // Copy and convert the parameter to lower-case for simple comparison
+  char mode_param[8] = {0};
+  strncpy(mode_param, pu8_input_value, len);
+  for (int i = 0; i < len; i++) {
+    mode_param[i] = tolower(mode_param[i]);
+  }
+
+  // Parse the parameter and prepare the corresponding ConnectionMode value
+  mrover_css_pwr_profile_t prof = (mrover_css_pwr_profile_t)0xFF;
+  if (strcmp(mode_param, "prof_a") == 0) {
+    prof = MROVER_CSS_PWR_PROFILE_A;
+  } else if (strcmp(mode_param, "prof_b") == 0) {
+    prof = MROVER_CSS_PWR_PROFILE_B;
+  } else {
+    Serial.println("Invalid protocol profile specified.");
+    Serial.println("Available modes: prof_a, prof_b");
+    return 1;
+  }
+  // Call the new protocol switch API to update the mode
+  app_SwSetCssPwrProfile(prof);
+
+  return 0;
 }

--- a/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/ArduinoSidewalkExample/oxit_cli_app.cpp
@@ -177,7 +177,7 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
  * @param pfun_uart_tx Function to send bytes over UART.
  * @return int Return status code.
  */
-static int sw_setCssPwrProfile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
+static int sw_set_css_pwr_profile_callback(const char *pu8_input_value, cli_send_bytes_t pfun_uart_tx);
 
 /******************************************************************************/
 /* Global Variable Definition */
@@ -266,10 +266,10 @@ cli_command_t cli_commands[] = {{
                                                 get_next_uplink_mtu_callback,
                                             },
                                             {
-                                                "sidewalk_ccs_prof_switch",
-                                                CLI_APP_NAME" sidewalk_ccs_prof_switch <profile>",
-                                                "To set the sidewalk ccs profile",
-                                                sw_setCssPwrProfile_callback,
+                                                "sidewalk_css_prof_switch",
+                                                CLI_APP_NAME" sidewalk_css_prof_switch <profile>",
+                                                "To set the sidewalk css profile",
+                                                sw_set_css_pwr_profile_callback,
                                             },
                                             };
 
@@ -608,18 +608,18 @@ static int get_next_uplink_mtu_callback(const char *pu8_input_value, cli_send_by
     return 0;
 }
 
-static int sw_setCssPwrProfile_callback(const char *pu8_input_value,
+static int sw_set_css_pwr_profile_callback(const char *pu8_input_value,
                                         cli_send_bytes_t pfun_uart_tx) {
   // Check if user supplied a mode string
   uint8_t len = strlen(pu8_input_value);
-  if (pu8_input_value == NULL || len == 0 || len > 8) {
-    Serial.println("Usage: sidewalk_ccs_prof_switch <profile>");
+  if (pu8_input_value == NULL || len == 0 || len > 7) {
+    Serial.println("Usage: sidewalk_css_prof_switch <profile>");
     Serial.println("Available modes: prof_a and prof_b");
     return 1;
   }
 
   // Copy and convert the parameter to lower-case for simple comparison
-  char mode_param[8] = {0};
+  char mode_param[7] = {0};
   strncpy(mode_param, pu8_input_value, len);
   for (int i = 0; i < len; i++) {
     mode_param[i] = tolower(mode_param[i]);

--- a/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
+++ b/Examples/ArduinoESP32S3FeatherSidewalk/mcm_release_versions.json
@@ -1,5 +1,5 @@
 {
-  "release_date": "2025-07-03",
+  "release_date": "2025-07-10",
   "versions": {
     "mcm": {
       "application": "0.5.8",
@@ -16,9 +16,9 @@
       }
     },
     "host": {
-      "application": "0.7.0",
-      "lib_mcm_rover": "0.4.0",
-      "lib_api_processor": "0.3.0"
+      "application": "0.8.0",
+      "lib_mcm_rover": "0.5.0",
+      "lib_api_processor": "0.4.0"
     }
   }
 }


### PR DESCRIPTION
- [ ] Introduction

This commit Introduces the ability to user to switch between  sidewalk CSS power  profiles via CMD. In addition to running the profile A as the default one.

- [ ] How to test
1. Wait for the device to be joined to the LNS.
2. Switch to CSS layer as the default is LoRaWAN via `oxit_cli protocol_switch sw_css` command.  Note, profile A is activated.
3. Switch to power profile B via `oxit_cli sidewalk_ccs_prof_switch prof_b` command. Logs will print out the results. 